### PR TITLE
Added initial focus command

### DIFF
--- a/src/commands/music/focus.ts
+++ b/src/commands/music/focus.ts
@@ -1,0 +1,85 @@
+import { Command, MessageProps, Track } from '../../@interfaces'
+import ytdl from '../../ytdl'
+import { durationFromSeconds } from '../../utils/duration'
+
+import bgMusic from '../../data/background-music.json'
+
+const focus: Command = {
+  regex: /^(f|focus)/,
+
+  async callback ( props: MessageProps ): Promise<void> {
+    
+    // If no pre-defined songs are found in data/background-music.json, do nothing
+    if (bgMusic.length === 0) return
+
+    // Choose random song from background-music.json
+    const song = bgMusic[Math.floor(Math.random() * bgMusic.length)];
+
+    const connection = await props.music.connect()
+
+    if (!connection) return
+
+    if () {
+      const track: Track = {
+        title: /[^\/]+((?=\#|\?)|$)/.exec(song.url)[0].replace(/(\?|\#).+/, ''),
+        duration: '00:00',
+        rawDuration: 0,
+        description: song.title,
+        author: props.author,
+        url: song.url,
+        thumbnail: null,
+      }
+  
+      await props.music.addTrack(track)
+      
+      return
+    }
+
+    const result: string = await ytdl(['-J', '-q', '-s', '-f', 'bestaudio', url])
+
+    const {
+      title,
+      description,
+      duration: rawDuration,
+      thumbnails,
+      formats,
+    }: {
+      title: string
+
+      description: string
+
+      duration: number
+
+      thumbnails: [{
+        url: string
+      }]
+
+      formats: [{
+        ext: string
+        url: string
+        acodec: string
+        format: string
+      }]
+    } = JSON.parse(result)
+
+    const isYoutube = /youtube.com|youtu.be/.test(url)
+
+    const source = isYoutube ? song.url : formats.find(({ format }) => /audio only/.test(format)).url
+
+    const duration = durationFromSeconds(rawDuration)
+
+    const track: Track = {
+      title,
+      duration,
+      rawDuration,
+      description,
+      author: props.author,
+      url: source,
+      thumbnail: thumbnails && thumbnails.reverse()[0].url,
+    }
+
+    await props.music.addTrack(track)
+  }
+}
+
+export default play

--- a/src/data/background-music.json
+++ b/src/data/background-music.json
@@ -1,0 +1,31 @@
+[
+    {
+        "url": "https://youtu.be/XULUBg_ZcAU",
+        "source": "youtube",
+        "type": "live",
+        "title": "Calm Piano Music 24/7: study music, focus, think, meditation, relaxing music",
+        "tags": [
+            "solo piano",
+            "calm",
+            "relaxing",
+            "focus",
+            "meditation",
+            "study"
+        ]
+    },
+    {
+        "url": "https://youtu.be/p7efQ4NTZcY",
+        "source": "youtube",
+        "type": "video",
+        "title": "DISNEY - The Piano Collections - Relaxing piano - Thugian Relist",
+        "tags": [
+            "disney",
+            "solo piano",
+            "calm",
+            "relaxing",
+            "focus",
+            "meditation",
+            "study"
+        ]
+    }
+]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "esModuleInterop": true,
     "declaration": true,
     "outDir": "./dist",
-    "baseUrl": "."
+    "baseUrl": ".",
+    "resolveJsonModule": true,
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
Often times I like to stream in talk and dev-talk during the daytime hours in order to get work done, but I also enjoy helping those that have questions and stop by in vc to ask me stuff. However, I like to have soothing solo piano or background music going on in the background at a low volume as it helps everyone concentrate. Scientists have done numerous studies that non-lyrical music, specifically classical, improves cognitive function in the brain. 

With the recent addition of Devcord's custom music bot, you all have changed the permissions so it can't speak in the non-music channel, but I am adding an initial version of a so-called `$focus` command in order to add some pre-approved background music that can be played in any of the voice channels without restrictions. The general idea is that all music associated with this command would be free of lyrics, so only instrumentals would be allowed.

I'll add improvements to this command over time, but wanted to get something out quickly so I can start using it in the meantime.